### PR TITLE
chore(gtfs-model): add new fields and mark old fileds as deprecated

### DIFF
--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/StopTime.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/StopTime.java
@@ -314,7 +314,13 @@ public final class StopTime extends IdentityBean<Integer> implements
     this.minArrivalTime = minArrivalTime;
   }
 
-  public int getStartPickupDropOffWindow() { return startPickupDropOffWindow; }
+  public int getStartPickupDropOffWindow() {
+    if (startPickupDropOffWindow != MISSING_VALUE) {
+      return startPickupDropOffWindow;
+    } else {
+      return minArrivalTime;
+    }
+  }
 
   public void setStartPickupDropOffWindow(int startPickupDropOffWindow) {
     this.startPickupDropOffWindow = startPickupDropOffWindow;
@@ -330,7 +336,13 @@ public final class StopTime extends IdentityBean<Integer> implements
     this.maxDepartureTime = maxDepartureTime;
   }
 
-  public int getEndPickupDropOffWindow() { return endPickupDropOffWindow; }
+  public int getEndPickupDropOffWindow() {
+    if (endPickupDropOffWindow != MISSING_VALUE) {
+      return endPickupDropOffWindow;
+    } else {
+      return maxDepartureTime;
+    }
+  }
 
   public void setEndPickupDropOffWindow(int endPickupDropOffWindow) {
     this.endPickupDropOffWindow = endPickupDropOffWindow;

--- a/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/StopTime.java
+++ b/onebusaway-gtfs/src/main/java/org/onebusaway/gtfs/model/StopTime.java
@@ -45,11 +45,27 @@ public final class StopTime extends IdentityBean<Integer> implements
   @CsvField(optional = true, mapping = StopTimeFieldMappingFactory.class)
   private int departureTime = MISSING_VALUE;
 
+  /**
+   * @deprecated
+   * GTFS-Flex v2.1 renamed this field. Use {@link #startPickupDropOffWindow} instead.
+   */
+  @Deprecated
   @CsvField(optional = true, mapping = StopTimeFieldMappingFactory.class)
   private int minArrivalTime = MISSING_VALUE;
 
+  @CsvField(optional = true, name = "start_pickup_dropoff_window", mapping = StopTimeFieldMappingFactory.class)
+  private int startPickupDropOffWindow = MISSING_VALUE;
+
+  /**
+   * @deprecated
+   * GTFS-Flex v2.1 renamed this field. Use {@link #endPickupDropOffWindow} instead.
+   */
+  @Deprecated
   @CsvField(optional = true, mapping = StopTimeFieldMappingFactory.class)
   private int maxDepartureTime = MISSING_VALUE;
+
+  @CsvField(optional = true, name = "end_pickup_dropoff_window", mapping = StopTimeFieldMappingFactory.class)
+  private int endPickupDropOffWindow = MISSING_VALUE;
 
   @CsvField(optional = true)
   private int timepoint = MISSING_VALUE;
@@ -129,7 +145,9 @@ public final class StopTime extends IdentityBean<Integer> implements
     this.id = st.id;
     this.pickupType = st.pickupType;
     this.minArrivalTime = st.minArrivalTime;
+    this.startPickupDropOffWindow = st.startPickupDropOffWindow;
     this.maxDepartureTime = st.maxDepartureTime;
+    this.endPickupDropOffWindow = st.endPickupDropOffWindow;
     this.continuousPickup = st.continuousPickup;
     this.continuousDropOff = st.continuousDropOff;
     this.routeShortName = st.routeShortName;
@@ -286,20 +304,36 @@ public final class StopTime extends IdentityBean<Integer> implements
     this.departureTime = MISSING_VALUE;
   }
 
+  @Deprecated
   public int getMinArrivalTime() {
     return minArrivalTime;
   }
 
+  @Deprecated
   public void setMinArrivalTime(int minArrivalTime) {
     this.minArrivalTime = minArrivalTime;
   }
 
+  public int getStartPickupDropOffWindow() { return startPickupDropOffWindow; }
+
+  public void setStartPickupDropOffWindow(int startPickupDropOffWindow) {
+    this.startPickupDropOffWindow = startPickupDropOffWindow;
+  }
+
+  @Deprecated
   public int getMaxDepartureTime() {
     return maxDepartureTime;
   }
 
+  @Deprecated
   public void setMaxDepartureTime(int maxDepartureTime) {
     this.maxDepartureTime = maxDepartureTime;
+  }
+
+  public int getEndPickupDropOffWindow() { return endPickupDropOffWindow; }
+
+  public void setEndPickupDropOffWindow(int endPickupDropOffWindow) {
+    this.endPickupDropOffWindow = endPickupDropOffWindow;
   }
 
   @Override


### PR DESCRIPTION
**Summary:**

This PR follows the update in [GTFS-Flex v2.1](https://docs.google.com/document/d/1PyYK6JVzz52XEx3FXqAJmoVefHFqZTHS4Mpn20dTuKE/edit?ts=5fc85991#bookmark=kix.nll7l9r3ccy6), the fields "min_arrival_time" and "max_departure_time" in stop_times.txt are renamed to "start_pickup_dropoff_window" and "end_pickup_dropoff_window", respectfully. New fields are added to the StopTime model and the old ones are marked as deprecated.

**Expected behavior:** 

GTFS containing both old and new field names in stop_times.txt are to be accepted by `onebusaway-gtfs` module.

- [x] Run the unit tests with `mvn test` to make sure you didn't break anything
- [ ] Format the title like "Fix #<issue_number> - short description of fix and changes"
- [ ] Linked all relevant issues
